### PR TITLE
Update package version to 0.7.0 and modify CSS file references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-library",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "type": "module",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -58,7 +58,7 @@ const pkg = {
   main: "./index.cjs",
   module: "./index.js",
   types: "./exports.d.ts",
-  style: "./styles.css",
+  style: "./ui-library.css",
 
   // Export map for modern tooling
   exports: {
@@ -68,7 +68,7 @@ const pkg = {
       types: "./exports.d.ts",
       default: "./index.js",
     },
-    "./ui-library.css": "./ui-library.css", // allow CSS import resolution
+    "./styles.css": "./ui-library.css", // allow CSS import resolution
   },
 
   files: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,6 @@ export default defineConfig({
         return false;
       },
       output: {
-        assetFileNames: "styles.css", // extract CSS to this file
-
         interop: "auto",
         globals: { vue: "Vue" },
       },


### PR DESCRIPTION
- Bumped version in package.json to 0.7.0.
- Changed CSS file reference in build.js from "styles.css" to "ui-library.css".
- Removed asset file name definition for CSS in Vite configuration.